### PR TITLE
CoverageProcessingFailedEvent added to queue-client

### DIFF
--- a/queue-client/src/main/java/tdl/participant/queue/events/CoverageProcessingFailedEvent.java
+++ b/queue-client/src/main/java/tdl/participant/queue/events/CoverageProcessingFailedEvent.java
@@ -1,0 +1,21 @@
+package tdl.participant.queue.events;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Value;
+import tdl.participant.queue.connector.QueueEvent;
+
+@Value
+@QueueEvent(name = "coverageProcessingFailed", version = "0.2")
+public class CoverageProcessingFailedEvent implements ParticipantEvent {
+    private final long timestampMillis;
+    private final String participant;
+    private final String challengeId;
+
+    public CoverageProcessingFailedEvent(@JsonProperty("timestampMillis") long timestampMillis,
+                                         @JsonProperty("participant") String participant,
+                                         @JsonProperty("challengeId") String challengeId) {
+        this.timestampMillis = timestampMillis;
+        this.participant = participant;
+        this.challengeId = challengeId;
+    }
+}


### PR DESCRIPTION
Add new event CoverageProcessingFailedEvent.java to track code coverage processing failures on the ECS

Related to PR https://github.com/julianghionoiu/dpnt-infra-events/pull/3